### PR TITLE
Fix 42 train with null val data

### DIFF
--- a/experiments/train.py
+++ b/experiments/train.py
@@ -78,13 +78,15 @@ print(f"\nMetadata for dataloader from file '{train_settings['train_hdf']}':")
 print_dictionary(metadata_train)
 
 if train_settings['val_hdf']:
-    dataloader_val,metadata_val = hdf_to_dataloader_pad(train_settings['val_hdf'],
+    dataloader_val, metadata_val = hdf_to_dataloader_pad(train_settings['val_hdf'],
                                                         n_users=train_settings['num_users'],
                                                         batch_size=train_settings['batch_size'],
                                                         padding_value=train_settings['padding_value']
                                                         )
     print(f"\nMetadata for dataloader from file '{train_settings['val_hdf']}':")
     print_dictionary(metadata_val)
+else:
+    dataloader_val, metadata_val = None, None
 
 # %% Get dimensions of the data
 dataiter = iter(dataloader_train)

--- a/experiments/train.py
+++ b/experiments/train.py
@@ -86,6 +86,7 @@ if train_settings['val_hdf']:
     print(f"\nMetadata for dataloader from file '{train_settings['val_hdf']}':")
     print_dictionary(metadata_val)
 else:
+    print("\nNo validation data specified during training.")
     dataloader_val, metadata_val = None, None
 
 # %% Get dimensions of the data


### PR DESCRIPTION
Resolves #42 
During training, if val data is null, it now trains instead of giving an error