### PR TITLE
Fix typo in ex1_eva_epochs settings

### DIFF
--- a/settings/settings_ex1_eval_epochs.json
+++ b/settings/settings_ex1_eval_epochs.json
@@ -2,7 +2,7 @@
     "num_users": 128,
     "batch_size": 4,
     "eval_hdf": "data/ex1/ex1_eval_epochs_data.hdf",
-    "models_dir": "models/ex1/eps1_128user",
+    "models_dir": "models/ex1/eps1_128users",
     "figs_dir": "figures/ex1/eps1_128users",
     "num_samples": 1,
     "padding_value": -1.0


### PR DESCRIPTION
Missing s